### PR TITLE
Added Wikipedia to the Who Uses list

### DIFF
--- a/pages/about.md
+++ b/pages/about.md
@@ -35,6 +35,7 @@ tests as well as with code reviews.
 Engineers from these companies and projects use JSHint:
 
 * [Mozilla](http://mozilla.org/)
+* [Wikipedia](http://wikipedia.org/)
 * [Facebook](https://facebook.com/)
 * [Twitter](https://twitter.com/)
 * [Bootstrap](http://getbootstrap.com/)


### PR DESCRIPTION
I received the following email:

```
Hi Anton,

On the page http://jshint.com/about/ you have a list of projects that use JSHint.

Do you mind adding Wikipedia, Wikimedia or MediaWiki there? We have it in our JavaScript coding conventions[1] and it runs automatically on each Git commit.

You can pick any name you want - "Wikipedia" is the popular site, "Wikimedia" is the organization and "MediaWiki" is the software.

I tried to find how to send this as a pull request, but couldn't find it in your repos ;)

Thank you!

[1] https://www.mediawiki.org/wiki/Manual:Coding_conventions/JavaScript
```