### PR TITLE
Implement deprecation notice

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,10 @@
     "build": "oddweb build ."
   },
   "dependencies": {
-    "dox": "^0.5.3",
-    "oddweb": "~0.0.4",
+    "dox": "^0.6.1",
     "jshint": "latest",
+    "marked": "^0.3.2",
+    "oddweb": "~0.0.4",
     "sqwish": "0.2.x",
     "uglify-js": "2.4.x"
   },

--- a/res/docs.css
+++ b/res/docs.css
@@ -49,3 +49,16 @@ a.anchor {
 .blog-list .link {
   padding-left: 20px;
 }
+
+.deprecation-msg {
+  margin-bottom: 1em;
+}
+
+.deprecation-msg strong {
+  font-weight: bold;
+}
+
+.deprecation-msg p {
+  display: inline;
+  margin: 0;
+}


### PR DESCRIPTION
Render a deprecation notice for options that have been labeled with the
JSDoc `@deprecated` tag.

Depends on https://github.com/jshint/jshint/pull/2122