### PR TITLE
Explicitly describe JSHint's default behavior

### DIFF
--- a/pages/docs.md
+++ b/pages/docs.md
@@ -31,15 +31,16 @@ If a file path is a dash (`-`) then JSHint will read from standard input.
 
 ### Configuration
 
-JSHint comes with a default set of warnings but it was designed to be very
-configurable. There are three main ways to configure your copy of JSHint:
-you can either specify the configuration file manually via the `--config` flag,
-use a special file `.jshintrc` or put your config into your projects `package.json`
-file under the `jshintConfig` property. In case of `.jshintrc`, JSHint will start
-looking for this file in the same directory as the file that's being linted.
-If not found, it will move one level up the directory tree all the way up to
-the filesystem root. (Note that if the input comes from stdin, JSHint doesn't
-attempt to find a configuration file)
+JSHint comes with [a default set of warnings](/docs/options/#default-behavior)
+but it was designed to be very configurable. There are three main ways to
+configure your copy of JSHint: you can either specify the configuration file
+manually via the `--config` flag, use a special file `.jshintrc` or put your
+config into your projects `package.json` file under the `jshintConfig`
+property. In case of `.jshintrc`, JSHint will start looking for this file in
+the same directory as the file that's being linted.  If not found, it will move
+one level up the directory tree all the way up to the filesystem root. (Note
+that if the input comes from stdin, JSHint doesn't attempt to find a
+configuration file)
 
 This setup allows you to have different configuration files per project. Place
 your file into the project root directory and, as long as you run JSHint from

--- a/pages/options.html
+++ b/pages/options.html
@@ -8,6 +8,17 @@ project repository</a>. If you spot an error, please <a href="{{ urls.newIssue
 }}">open an issue</a> or (better yet) <a href="{{ urls.newPullRequest }}">make
 a pull request</a>!
 
+<h3 id="default-behavior">Default Behavior</h3>
+
+JSHint will impose some constraints by default. If you would like to make
+JSHint less strict, you can do so by enabling specific Relaxing options (<a
+href="http://jshint.com/docs/options/#relaxing-options">see the full list of
+Relaxing options</a>). If you would like to make JSHint more strict, you can do
+so by enabling specific Enforcing options (<a
+href="http://jshint.com/docs/options/#enforcing-options">see full list of
+Enforcing options</a>). JSHint may be configured with whatever combination of
+these options you like.
+
 <h3><a class="anchor" href="#enforcing-options" name="enforcing-options">Enforcing options</a></h3>
 
 <p>When set to true, these options will make JSHint produce more warnings about your code.</p>


### PR DESCRIPTION
More clearly define how JSHint will behave in the absence of a
user-defined configuration file.