### PR TITLE
Marked: Add anchors to headings - jshint/jshint#2938

### DIFF
--- a/plugins/variables.js
+++ b/plugins/variables.js
@@ -10,6 +10,23 @@ var readOptions = require("./util/read-options");
 var translateFencedCode = require("./util/fenced-code");
 var optionsSrc = __dirname + "/../res/jshint/src/options.js";
 
+/**
+ * Marked renderer that adds anchors to headings
+ * https://github.com/chjj/marked#overriding-renderer-methods
+ */
+var renderer = new marked.Renderer();
+
+renderer.heading = function (text, level) {
+  var escapedText = text.toLowerCase().replace(/[^\w]+/g, '-');
+
+  return '<h'+level+'>'+
+           '<a name="'+escapedText+'" class="anchor" href="#'+escapedText+'">'+
+             '<span class="header-link"></span>'+
+           '</a>'+text+
+         '</h'+level+'>';
+};
+
+
 var pkg = require(path.join(
   __dirname, "..", "res", "jshint", "package.json")
 );
@@ -36,7 +53,7 @@ module.exports = function (site, handlebars) {
   var partialPattern = /^(.*)\.html$/i;
 
   handlebars.registerHelper("markdown", function (input) {
-    return new handlebars.SafeString(marked(input));
+    return new handlebars.SafeString(marked(input, {renderer: renderer}));
   });
 
   fs.readdirSync("partials").forEach(function(filename) {


### PR DESCRIPTION
Custom renderer for heading tags will add anchors to all headings in
rendered markdown content. Anchors are slug-like representations of the
heading text, same format as GFM.

Code from https://github.com/chjj/marked#overriding-renderer-methods
(MIT license)

Might need some CSS tweaks but just wanted to see if the code change
was acceptable first.