### PR TITLE
Small suggestion: "Use together with" -> "affects"

### DIFF
--- a/pages/docs.md
+++ b/pages/docs.md
@@ -94,7 +94,7 @@ A directive for setting JSHint-compatible JSLint options.
 
 A directive for telling JSHint about global variables that are defined
 elsewhere. If value is `false` (default), JSHint will consider that variable
-as read-only. Use it together with the `undef` option.
+as read-only. Affects the `undef` option.
 
     /* globals MY_LIB: false */
 
@@ -106,7 +106,7 @@ anywhere in the current file.
 #### exported
 
 A directive for telling JSHint about global variables that are defined in the
-current file but used elsewhere. Use it together with the `unused` option.
+current file but used elsewhere. Affects the `unused` option.
 
     /* exported EXPORTED_LIB */
 


### PR DESCRIPTION
Some developers on my team were confused with the wording of the documentation regarding `exported`.  It says to use the `exported` comment together with the `unused` option.  In our case, we enable the `unused` option in .jshintrc, but they thought that the `unused` had to be set in the same file if they wanted to use `exported`.

Small suggestion: could just state that the `exported` setting affects the `unused` option instead of stating that they must be used together, as "together" could be misinterpreted to imply that the settings must be set at the same time in the same configuration file/block.